### PR TITLE
fix Error: No named parameter with the name 'baseUrl'.

### DIFF
--- a/lib/src/widget/impl/turnstile_widget.dart
+++ b/lib/src/widget/impl/turnstile_widget.dart
@@ -337,7 +337,7 @@ class _CloudflareTurnstileState extends State<CloudflareTurnstile> {
     super.initState();
 
     // Check if the platform is supported
-    if (!(Platform.isAndroid || Platform.isIOS)) {
+    if (!(Platform.isAndroid || Platform.isIOS || Platform.isMacOS)) {
       throw UnsupportedError(
         'CloudflareTurnstile only supports Android, iOS and Web platforms.',
       );
@@ -575,9 +575,9 @@ class _TurnstileInvisible extends CloudflareTurnstile {
           onTokenExpired: onTokenExpired,
         ) {
     // Check if the platform is supported
-    if (!(Platform.isAndroid || Platform.isIOS)) {
+    if (!(Platform.isAndroid || Platform.isIOS || Platform.isMacOS)) {
       throw UnsupportedError(
-        'CloudflareTurnstile only supports Android, iOS and Web platforms.',
+        'CloudflareTurnstile only supports Android, iOS, MacOs and Web platforms.',
       );
     }
 

--- a/lib/src/widget/impl/turnstile_widget_web.dart
+++ b/lib/src/widget/impl/turnstile_widget_web.dart
@@ -227,6 +227,7 @@ class CloudflareTurnstile extends StatefulWidget
     required String siteKey,
     String? action,
     String? cData,
+    String? baseUrl,
     i.OnTokenReceived? onTokenReceived,
     i.OnTokenExpired? onTokenExpired,
     TurnstileOptions? options,


### PR DESCRIPTION
This code got error when run `flutter run -d chrome`, It works on Android, IOS
```
late CloudflareTurnstile turnstile;
    if (kIsWeb) {
      turnstile = CloudflareTurnstile.invisible(
        siteKey: AppEnv().turnstileSiteKey, // Replace with your actual site key
      );
    } else if (Platform.isAndroid || Platform.isIOS || Platform.isMacOS) {
      turnstile = CloudflareTurnstile.invisible(
        siteKey: AppEnv().turnstileSiteKey, // Replace with your actual site key
        baseUrl: AppEnv().turnstileHost,
      );
    } else {
      return null;
    }
```

related #27 