### PR TITLE
fix: resolve widget failing to render on page refresh

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -21,25 +21,64 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class HomePage extends StatefulWidget {
+class HomePage extends StatelessWidget {
   const HomePage({super.key});
 
   @override
-  State<HomePage> createState() => _HomePageState();
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Cloudflare Turnstile Example'),
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            ElevatedButton.icon(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const VisibleTurnstilePage(),
+                  ),
+                );
+              },
+              icon: const Icon(Icons.security),
+              label: const Text('Visible Turnstile'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton.icon(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const InvisibleTurnstilePage(),
+                  ),
+                );
+              },
+              icon: const Icon(Icons.visibility_off),
+              label: const Text('Invisible Turnstile'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }
 
-class _HomePageState extends State<HomePage> {
+/// Example: Visible Turnstile Widget
+class VisibleTurnstilePage extends StatefulWidget {
+  const VisibleTurnstilePage({super.key});
+
+  @override
+  State<VisibleTurnstilePage> createState() => _VisibleTurnstilePageState();
+}
+
+class _VisibleTurnstilePageState extends State<VisibleTurnstilePage> {
   final TurnstileController _controller = TurnstileController();
   String? _token;
   String? _widgetId;
-  int _mountCount = 0;
-  bool _showWidget = true;
-
-  @override
-  void initState() {
-    super.initState();
-    _mountCount++;
-  }
 
   @override
   void dispose() {
@@ -51,67 +90,42 @@ class _HomePageState extends State<HomePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Turnstile Refresh Test'),
+        title: const Text('Visible Turnstile'),
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
       ),
       body: Center(
         child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 500),
+          constraints: const BoxConstraints(maxWidth: 400),
           child: SingleChildScrollView(
             padding: const EdgeInsets.all(16.0),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                _buildTestInstructions(),
-                const SizedBox(height: 16),
-                _buildInfoCard(
-                  title: 'Mount Count',
-                  value: '$_mountCount (increases on hot reload, not F5)',
-                  color: Colors.purple,
+                Center(
+                  child: CloudflareTurnstile(
+                    siteKey: '3x00000000000000000000FF', // Test site key
+                    controller: _controller,
+                    options: TurnstileOptions(
+                      size: TurnstileSize.flexible,
+                      theme: TurnstileTheme.light,
+                    ),
+                    onTokenReceived: (token) {
+                      setState(() {
+                        _token = token;
+                        _widgetId = _controller.widgetId;
+                      });
+                    },
+                    onTokenExpired: () {
+                      setState(() => _token = null);
+                    },
+                    onError: (error) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text('Error: ${error.message}')),
+                      );
+                    },
+                  ),
                 ),
-                const SizedBox(height: 12),
-                if (_showWidget)
-                  Center(
-                    child: CloudflareTurnstile(
-                      siteKey: '3x00000000000000000000FF',
-                      controller: _controller,
-                      options: TurnstileOptions(
-                        size: TurnstileSize.flexible,
-                        theme: TurnstileTheme.light,
-                      ),
-                      onTokenReceived: (token) {
-                        setState(() {
-                          _token = token;
-                          _widgetId = _controller.widgetId;
-                        });
-                      },
-                      onTokenExpired: () {
-                        setState(() => _token = null);
-                      },
-                      onError: (error) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Text('Error: ${error.message}'),
-                            backgroundColor: Colors.red,
-                          ),
-                        );
-                      },
-                    ),
-                  ),
-                if (!_showWidget)
-                  Container(
-                    height: 65,
-                    alignment: Alignment.center,
-                    decoration: BoxDecoration(
-                      border: Border.all(color: Colors.grey.shade300),
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    child: const Text(
-                      'Widget removed',
-                      style: TextStyle(color: Colors.grey),
-                    ),
-                  ),
-                const SizedBox(height: 16),
+                const SizedBox(height: 24),
                 _buildInfoCard(
                   title: 'Widget ID',
                   value: _widgetId ?? 'Not assigned',
@@ -125,33 +139,8 @@ class _HomePageState extends State<HomePage> {
                   isMonospace: true,
                 ),
                 const SizedBox(height: 24),
-                const Text(
-                  'Test Actions',
-                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
-                ),
-                const SizedBox(height: 12),
                 Row(
                   children: [
-                    Expanded(
-                      child: ElevatedButton.icon(
-                        onPressed: () {
-                          setState(() {
-                            _showWidget = !_showWidget;
-                            if (!_showWidget) {
-                              _token = null;
-                              _widgetId = null;
-                            }
-                          });
-                        },
-                        icon: Icon(
-                          _showWidget ? Icons.visibility_off : Icons.visibility,
-                        ),
-                        label: Text(
-                          _showWidget ? 'Remove Widget' : 'Add Widget',
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: 12),
                     Expanded(
                       child: ElevatedButton.icon(
                         onPressed: () async {
@@ -159,88 +148,41 @@ class _HomePageState extends State<HomePage> {
                           await _controller.refreshToken();
                         },
                         icon: const Icon(Icons.refresh),
-                        label: const Text('Refresh Token'),
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 12),
-                Row(
-                  children: [
-                    Expanded(
-                      child: ElevatedButton.icon(
-                        onPressed: () {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (_) => const OtherPage(),
-                            ),
-                          );
-                        },
-                        icon: const Icon(Icons.navigate_next),
-                        label: const Text('Navigate Away'),
+                        label: const Text('Refresh'),
                       ),
                     ),
                     const SizedBox(width: 12),
                     Expanded(
                       child: ElevatedButton.icon(
-                        onPressed: () {
-                          Navigator.pushReplacement(
-                            context,
-                            MaterialPageRoute(
-                              builder: (_) => const HomePage(),
-                            ),
-                          );
-                        },
-                        icon: const Icon(Icons.swap_horiz),
-                        label: const Text('Replace Page'),
+                        onPressed: _token != null
+                            ? () async {
+                                final isExpired = await _controller.isExpired();
+                                if (context.mounted) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(
+                                      content: Text(
+                                        isExpired
+                                            ? 'Token expired'
+                                            : 'Token valid',
+                                      ),
+                                      backgroundColor: isExpired
+                                          ? Colors.orange
+                                          : Colors.green,
+                                    ),
+                                  );
+                                }
+                              }
+                            : null,
+                        icon: const Icon(Icons.check_circle),
+                        label: const Text('Validate'),
                       ),
                     ),
                   ],
-                ),
-                const SizedBox(height: 12),
-                ElevatedButton.icon(
-                  onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => const SecondTurnstilePage(),
-                      ),
-                    );
-                  },
-                  icon: const Icon(Icons.add),
-                  label: const Text('Open Second Turnstile Page'),
                 ),
               ],
             ),
           ),
         ),
-      ),
-    );
-  }
-
-  Widget _buildTestInstructions() {
-    return Container(
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: Colors.amber.shade50,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: Colors.amber.shade200),
-      ),
-      child: const Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            'Test Scenarios:',
-            style: TextStyle(fontWeight: FontWeight.bold),
-          ),
-          SizedBox(height: 4),
-          Text('1. Press F5 - widget should re-render without errors'),
-          Text('2. "Remove Widget" then "Add Widget" - should re-render'),
-          Text('3. "Navigate Away" then back - should re-render'),
-          Text('4. "Replace Page" - old widget cleaned up, new one renders'),
-          Text('5. Open console - no "widget already exists" errors'),
-        ],
       ),
     );
   }
@@ -263,7 +205,10 @@ class _HomePageState extends State<HomePage> {
         children: [
           Text(
             title,
-            style: TextStyle(fontWeight: FontWeight.bold, color: color),
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              color: color,
+            ),
           ),
           const SizedBox(height: 4),
           Text(
@@ -272,8 +217,6 @@ class _HomePageState extends State<HomePage> {
               fontSize: 12,
               fontFamily: isMonospace ? 'monospace' : null,
             ),
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
           ),
         ],
       ),
@@ -281,68 +224,69 @@ class _HomePageState extends State<HomePage> {
   }
 }
 
-class OtherPage extends StatelessWidget {
-  const OtherPage({super.key});
+/// Example: Invisible Turnstile Widget
+class InvisibleTurnstilePage extends StatefulWidget {
+  const InvisibleTurnstilePage({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Other Page'),
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-      ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Icon(Icons.check_circle, size: 64, color: Colors.green),
-            const SizedBox(height: 16),
-            const Text(
-              'Navigated away from Turnstile',
-              style: TextStyle(fontSize: 18),
-            ),
-            const SizedBox(height: 8),
-            const Text(
-              'The widget should have been disposed.\n'
-              'Press back and verify it re-renders.',
-              textAlign: TextAlign.center,
-              style: TextStyle(color: Colors.grey),
-            ),
-            const SizedBox(height: 24),
-            ElevatedButton.icon(
-              onPressed: () => Navigator.pop(context),
-              icon: const Icon(Icons.arrow_back),
-              label: const Text('Go Back'),
-            ),
-          ],
-        ),
-      ),
+  State<InvisibleTurnstilePage> createState() => _InvisibleTurnstilePageState();
+}
+
+class _InvisibleTurnstilePageState extends State<InvisibleTurnstilePage> {
+  late CloudflareTurnstile _turnstile;
+  String? _token;
+  bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _turnstile = CloudflareTurnstile.invisible(
+      siteKey: '1x00000000000000000000BB', // Test site key
+      onTokenReceived: (token) {
+        if (mounted) {
+          setState(() {
+            _token = token;
+            _isLoading = false;
+          });
+        }
+      },
+      onTokenExpired: () {
+        if (mounted) setState(() => _token = null);
+      },
     );
   }
-}
-
-class SecondTurnstilePage extends StatefulWidget {
-  const SecondTurnstilePage({super.key});
-
-  @override
-  State<SecondTurnstilePage> createState() => _SecondTurnstilePageState();
-}
-
-class _SecondTurnstilePageState extends State<SecondTurnstilePage> {
-  final TurnstileController _controller = TurnstileController();
-  String? _token;
 
   @override
   void dispose() {
-    _controller.dispose();
+    _turnstile.dispose();
     super.dispose();
+  }
+
+  Future<void> _getToken() async {
+    setState(() => _isLoading = true);
+    try {
+      final token = await _turnstile.getToken();
+      if (mounted) {
+        setState(() {
+          _token = token;
+          _isLoading = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() => _isLoading = false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Error: $e')),
+        );
+      }
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Second Turnstile'),
+        title: const Text('Invisible Turnstile'),
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
       ),
       body: Center(
@@ -351,50 +295,134 @@ class _SecondTurnstilePageState extends State<SecondTurnstilePage> {
           child: SingleChildScrollView(
             padding: const EdgeInsets.all(16.0),
             child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                const Text(
-                  'This page has its own Turnstile widget.\n'
-                  'Tests multiple widgets across navigation.',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(color: Colors.grey),
-                ),
-                const SizedBox(height: 24),
-                CloudflareTurnstile(
-                  siteKey: '3x00000000000000000000FF',
-                  controller: _controller,
-                  options: TurnstileOptions(
-                    size: TurnstileSize.flexible,
-                    theme: TurnstileTheme.light,
-                  ),
-                  onTokenReceived: (token) {
-                    setState(() => _token = token);
-                  },
-                  onError: (error) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text('Error: ${error.message}')),
-                    );
-                  },
+                const Center(
+                  child:
+                      Icon(Icons.visibility_off, size: 64, color: Colors.blue),
                 ),
                 const SizedBox(height: 16),
-                Container(
-                  padding: const EdgeInsets.all(12),
-                  decoration: BoxDecoration(
-                    color: (_token != null ? Colors.green : Colors.grey)
-                        .withValues(alpha: 0.1),
-                    borderRadius: BorderRadius.circular(8),
-                  ),
+                const Center(
                   child: Text(
-                    _token != null ? 'Token received' : 'Waiting...',
-                    style: TextStyle(
-                      color: _token != null ? Colors.green : Colors.grey,
-                      fontWeight: FontWeight.bold,
-                    ),
+                    'Invisible Turnstile',
+                    style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
                   ),
                 ),
+                const SizedBox(height: 8),
+                const Center(
+                  child: Text(
+                    'Runs in the background without UI',
+                    style: TextStyle(color: Colors.grey),
+                  ),
+                ),
+                const SizedBox(height: 24),
+                _buildInfoCard(
+                  title: 'Widget ID',
+                  value: _turnstile.id ?? 'Not assigned',
+                  color: _turnstile.id != null ? Colors.blue : Colors.grey,
+                ),
+                const SizedBox(height: 12),
+                _buildInfoCard(
+                  title: 'Token',
+                  value: _token ?? 'No token yet',
+                  color: _token != null ? Colors.green : Colors.grey,
+                  isMonospace: true,
+                ),
+                const SizedBox(height: 24),
+                if (_isLoading)
+                  const Center(child: CircularProgressIndicator())
+                else
+                  Column(
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: ElevatedButton.icon(
+                              onPressed: _getToken,
+                              icon: const Icon(Icons.key),
+                              label: const Text('Get Token'),
+                            ),
+                          ),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: ElevatedButton.icon(
+                              onPressed: () async {
+                                setState(() => _isLoading = true);
+                                await _turnstile.refresh();
+                                setState(() => _isLoading = false);
+                              },
+                              icon: const Icon(Icons.refresh),
+                              label: const Text('Refresh'),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 12),
+                      ElevatedButton.icon(
+                        onPressed: _token != null
+                            ? () async {
+                                final isExpired = await _turnstile.isExpired();
+                                if (context.mounted) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(
+                                      content: Text(
+                                        isExpired
+                                            ? 'Token expired'
+                                            : 'Token valid',
+                                      ),
+                                      backgroundColor: isExpired
+                                          ? Colors.orange
+                                          : Colors.green,
+                                    ),
+                                  );
+                                }
+                              }
+                            : null,
+                        icon: const Icon(Icons.check_circle),
+                        label: const Text('Validate Token'),
+                      ),
+                    ],
+                  ),
               ],
             ),
           ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildInfoCard({
+    required String title,
+    required String value,
+    required Color color,
+    bool isMonospace = false,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withValues(alpha: 0.3)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              color: color,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            value,
+            style: TextStyle(
+              fontSize: 12,
+              fontFamily: isMonospace ? 'monospace' : null,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -21,64 +21,25 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class HomePage extends StatelessWidget {
+class HomePage extends StatefulWidget {
   const HomePage({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Cloudflare Turnstile Example'),
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-      ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            ElevatedButton.icon(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => const VisibleTurnstilePage(),
-                  ),
-                );
-              },
-              icon: const Icon(Icons.security),
-              label: const Text('Visible Turnstile'),
-            ),
-            const SizedBox(height: 16),
-            ElevatedButton.icon(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => const InvisibleTurnstilePage(),
-                  ),
-                );
-              },
-              icon: const Icon(Icons.visibility_off),
-              label: const Text('Invisible Turnstile'),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
+  State<HomePage> createState() => _HomePageState();
 }
 
-/// Example: Visible Turnstile Widget
-class VisibleTurnstilePage extends StatefulWidget {
-  const VisibleTurnstilePage({super.key});
-
-  @override
-  State<VisibleTurnstilePage> createState() => _VisibleTurnstilePageState();
-}
-
-class _VisibleTurnstilePageState extends State<VisibleTurnstilePage> {
+class _HomePageState extends State<HomePage> {
   final TurnstileController _controller = TurnstileController();
   String? _token;
   String? _widgetId;
+  int _mountCount = 0;
+  bool _showWidget = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _mountCount++;
+  }
 
   @override
   void dispose() {
@@ -90,42 +51,67 @@ class _VisibleTurnstilePageState extends State<VisibleTurnstilePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Visible Turnstile'),
+        title: const Text('Turnstile Refresh Test'),
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
       ),
       body: Center(
         child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 400),
+          constraints: const BoxConstraints(maxWidth: 500),
           child: SingleChildScrollView(
             padding: const EdgeInsets.all(16.0),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Center(
-                  child: CloudflareTurnstile(
-                    siteKey: '3x00000000000000000000FF', // Test site key
-                    controller: _controller,
-                    options: TurnstileOptions(
-                      size: TurnstileSize.flexible,
-                      theme: TurnstileTheme.light,
-                    ),
-                    onTokenReceived: (token) {
-                      setState(() {
-                        _token = token;
-                        _widgetId = _controller.widgetId;
-                      });
-                    },
-                    onTokenExpired: () {
-                      setState(() => _token = null);
-                    },
-                    onError: (error) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(content: Text('Error: ${error.message}')),
-                      );
-                    },
-                  ),
+                _buildTestInstructions(),
+                const SizedBox(height: 16),
+                _buildInfoCard(
+                  title: 'Mount Count',
+                  value: '$_mountCount (increases on hot reload, not F5)',
+                  color: Colors.purple,
                 ),
-                const SizedBox(height: 24),
+                const SizedBox(height: 12),
+                if (_showWidget)
+                  Center(
+                    child: CloudflareTurnstile(
+                      siteKey: '3x00000000000000000000FF',
+                      controller: _controller,
+                      options: TurnstileOptions(
+                        size: TurnstileSize.flexible,
+                        theme: TurnstileTheme.light,
+                      ),
+                      onTokenReceived: (token) {
+                        setState(() {
+                          _token = token;
+                          _widgetId = _controller.widgetId;
+                        });
+                      },
+                      onTokenExpired: () {
+                        setState(() => _token = null);
+                      },
+                      onError: (error) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text('Error: ${error.message}'),
+                            backgroundColor: Colors.red,
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                if (!_showWidget)
+                  Container(
+                    height: 65,
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                      border: Border.all(color: Colors.grey.shade300),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: const Text(
+                      'Widget removed',
+                      style: TextStyle(color: Colors.grey),
+                    ),
+                  ),
+                const SizedBox(height: 16),
                 _buildInfoCard(
                   title: 'Widget ID',
                   value: _widgetId ?? 'Not assigned',
@@ -139,8 +125,33 @@ class _VisibleTurnstilePageState extends State<VisibleTurnstilePage> {
                   isMonospace: true,
                 ),
                 const SizedBox(height: 24),
+                const Text(
+                  'Test Actions',
+                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+                ),
+                const SizedBox(height: 12),
                 Row(
                   children: [
+                    Expanded(
+                      child: ElevatedButton.icon(
+                        onPressed: () {
+                          setState(() {
+                            _showWidget = !_showWidget;
+                            if (!_showWidget) {
+                              _token = null;
+                              _widgetId = null;
+                            }
+                          });
+                        },
+                        icon: Icon(
+                          _showWidget ? Icons.visibility_off : Icons.visibility,
+                        ),
+                        label: Text(
+                          _showWidget ? 'Remove Widget' : 'Add Widget',
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
                     Expanded(
                       child: ElevatedButton.icon(
                         onPressed: () async {
@@ -148,41 +159,88 @@ class _VisibleTurnstilePageState extends State<VisibleTurnstilePage> {
                           await _controller.refreshToken();
                         },
                         icon: const Icon(Icons.refresh),
-                        label: const Text('Refresh'),
+                        label: const Text('Refresh Token'),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    Expanded(
+                      child: ElevatedButton.icon(
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => const OtherPage(),
+                            ),
+                          );
+                        },
+                        icon: const Icon(Icons.navigate_next),
+                        label: const Text('Navigate Away'),
                       ),
                     ),
                     const SizedBox(width: 12),
                     Expanded(
                       child: ElevatedButton.icon(
-                        onPressed: _token != null
-                            ? () async {
-                                final isExpired = await _controller.isExpired();
-                                if (context.mounted) {
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    SnackBar(
-                                      content: Text(
-                                        isExpired
-                                            ? 'Token expired'
-                                            : 'Token valid',
-                                      ),
-                                      backgroundColor: isExpired
-                                          ? Colors.orange
-                                          : Colors.green,
-                                    ),
-                                  );
-                                }
-                              }
-                            : null,
-                        icon: const Icon(Icons.check_circle),
-                        label: const Text('Validate'),
+                        onPressed: () {
+                          Navigator.pushReplacement(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => const HomePage(),
+                            ),
+                          );
+                        },
+                        icon: const Icon(Icons.swap_horiz),
+                        label: const Text('Replace Page'),
                       ),
                     ),
                   ],
+                ),
+                const SizedBox(height: 12),
+                ElevatedButton.icon(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const SecondTurnstilePage(),
+                      ),
+                    );
+                  },
+                  icon: const Icon(Icons.add),
+                  label: const Text('Open Second Turnstile Page'),
                 ),
               ],
             ),
           ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildTestInstructions() {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.amber.shade50,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Colors.amber.shade200),
+      ),
+      child: const Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Test Scenarios:',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          SizedBox(height: 4),
+          Text('1. Press F5 - widget should re-render without errors'),
+          Text('2. "Remove Widget" then "Add Widget" - should re-render'),
+          Text('3. "Navigate Away" then back - should re-render'),
+          Text('4. "Replace Page" - old widget cleaned up, new one renders'),
+          Text('5. Open console - no "widget already exists" errors'),
+        ],
       ),
     );
   }
@@ -205,10 +263,7 @@ class _VisibleTurnstilePageState extends State<VisibleTurnstilePage> {
         children: [
           Text(
             title,
-            style: TextStyle(
-              fontWeight: FontWeight.bold,
-              color: color,
-            ),
+            style: TextStyle(fontWeight: FontWeight.bold, color: color),
           ),
           const SizedBox(height: 4),
           Text(
@@ -217,6 +272,8 @@ class _VisibleTurnstilePageState extends State<VisibleTurnstilePage> {
               fontSize: 12,
               fontFamily: isMonospace ? 'monospace' : null,
             ),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
           ),
         ],
       ),
@@ -224,69 +281,68 @@ class _VisibleTurnstilePageState extends State<VisibleTurnstilePage> {
   }
 }
 
-/// Example: Invisible Turnstile Widget
-class InvisibleTurnstilePage extends StatefulWidget {
-  const InvisibleTurnstilePage({super.key});
+class OtherPage extends StatelessWidget {
+  const OtherPage({super.key});
 
   @override
-  State<InvisibleTurnstilePage> createState() => _InvisibleTurnstilePageState();
-}
-
-class _InvisibleTurnstilePageState extends State<InvisibleTurnstilePage> {
-  late CloudflareTurnstile _turnstile;
-  String? _token;
-  bool _isLoading = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _turnstile = CloudflareTurnstile.invisible(
-      siteKey: '1x00000000000000000000BB', // Test site key
-      onTokenReceived: (token) {
-        if (mounted) {
-          setState(() {
-            _token = token;
-            _isLoading = false;
-          });
-        }
-      },
-      onTokenExpired: () {
-        if (mounted) setState(() => _token = null);
-      },
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Other Page'),
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.check_circle, size: 64, color: Colors.green),
+            const SizedBox(height: 16),
+            const Text(
+              'Navigated away from Turnstile',
+              style: TextStyle(fontSize: 18),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'The widget should have been disposed.\n'
+              'Press back and verify it re-renders.',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: Colors.grey),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton.icon(
+              onPressed: () => Navigator.pop(context),
+              icon: const Icon(Icons.arrow_back),
+              label: const Text('Go Back'),
+            ),
+          ],
+        ),
+      ),
     );
   }
+}
+
+class SecondTurnstilePage extends StatefulWidget {
+  const SecondTurnstilePage({super.key});
+
+  @override
+  State<SecondTurnstilePage> createState() => _SecondTurnstilePageState();
+}
+
+class _SecondTurnstilePageState extends State<SecondTurnstilePage> {
+  final TurnstileController _controller = TurnstileController();
+  String? _token;
 
   @override
   void dispose() {
-    _turnstile.dispose();
+    _controller.dispose();
     super.dispose();
-  }
-
-  Future<void> _getToken() async {
-    setState(() => _isLoading = true);
-    try {
-      final token = await _turnstile.getToken();
-      if (mounted) {
-        setState(() {
-          _token = token;
-          _isLoading = false;
-        });
-      }
-    } catch (e) {
-      if (mounted) {
-        setState(() => _isLoading = false);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Error: $e')),
-        );
-      }
-    }
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Invisible Turnstile'),
+        title: const Text('Second Turnstile'),
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
       ),
       body: Center(
@@ -295,134 +351,50 @@ class _InvisibleTurnstilePageState extends State<InvisibleTurnstilePage> {
           child: SingleChildScrollView(
             padding: const EdgeInsets.all(16.0),
             child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                const Center(
-                  child:
-                      Icon(Icons.visibility_off, size: 64, color: Colors.blue),
+                const Text(
+                  'This page has its own Turnstile widget.\n'
+                  'Tests multiple widgets across navigation.',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(color: Colors.grey),
+                ),
+                const SizedBox(height: 24),
+                CloudflareTurnstile(
+                  siteKey: '3x00000000000000000000FF',
+                  controller: _controller,
+                  options: TurnstileOptions(
+                    size: TurnstileSize.flexible,
+                    theme: TurnstileTheme.light,
+                  ),
+                  onTokenReceived: (token) {
+                    setState(() => _token = token);
+                  },
+                  onError: (error) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text('Error: ${error.message}')),
+                    );
+                  },
                 ),
                 const SizedBox(height: 16),
-                const Center(
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: (_token != null ? Colors.green : Colors.grey)
+                        .withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
                   child: Text(
-                    'Invisible Turnstile',
-                    style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                    _token != null ? 'Token received' : 'Waiting...',
+                    style: TextStyle(
+                      color: _token != null ? Colors.green : Colors.grey,
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                 ),
-                const SizedBox(height: 8),
-                const Center(
-                  child: Text(
-                    'Runs in the background without UI',
-                    style: TextStyle(color: Colors.grey),
-                  ),
-                ),
-                const SizedBox(height: 24),
-                _buildInfoCard(
-                  title: 'Widget ID',
-                  value: _turnstile.id ?? 'Not assigned',
-                  color: _turnstile.id != null ? Colors.blue : Colors.grey,
-                ),
-                const SizedBox(height: 12),
-                _buildInfoCard(
-                  title: 'Token',
-                  value: _token ?? 'No token yet',
-                  color: _token != null ? Colors.green : Colors.grey,
-                  isMonospace: true,
-                ),
-                const SizedBox(height: 24),
-                if (_isLoading)
-                  const Center(child: CircularProgressIndicator())
-                else
-                  Column(
-                    children: [
-                      Row(
-                        children: [
-                          Expanded(
-                            child: ElevatedButton.icon(
-                              onPressed: _getToken,
-                              icon: const Icon(Icons.key),
-                              label: const Text('Get Token'),
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          Expanded(
-                            child: ElevatedButton.icon(
-                              onPressed: () async {
-                                setState(() => _isLoading = true);
-                                await _turnstile.refresh();
-                                setState(() => _isLoading = false);
-                              },
-                              icon: const Icon(Icons.refresh),
-                              label: const Text('Refresh'),
-                            ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 12),
-                      ElevatedButton.icon(
-                        onPressed: _token != null
-                            ? () async {
-                                final isExpired = await _turnstile.isExpired();
-                                if (context.mounted) {
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    SnackBar(
-                                      content: Text(
-                                        isExpired
-                                            ? 'Token expired'
-                                            : 'Token valid',
-                                      ),
-                                      backgroundColor: isExpired
-                                          ? Colors.orange
-                                          : Colors.green,
-                                    ),
-                                  );
-                                }
-                              }
-                            : null,
-                        icon: const Icon(Icons.check_circle),
-                        label: const Text('Validate Token'),
-                      ),
-                    ],
-                  ),
               ],
             ),
           ),
         ),
-      ),
-    );
-  }
-
-  Widget _buildInfoCard({
-    required String title,
-    required String value,
-    required Color color,
-    bool isMonospace = false,
-  }) {
-    return Container(
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.1),
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: color.withValues(alpha: 0.3)),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            title,
-            style: TextStyle(
-              fontWeight: FontWeight.bold,
-              color: color,
-            ),
-          ),
-          const SizedBox(height: 4),
-          Text(
-            value,
-            style: TextStyle(
-              fontSize: 12,
-              fontFamily: isMonospace ? 'monospace' : null,
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/lib/src/controller/impl/turnstile_controller.dart
+++ b/lib/src/controller/impl/turnstile_controller.dart
@@ -46,6 +46,7 @@ class TurnstileController extends ChangeNotifier
   TurnstileException? get error => _error;
 
   /// Sets a new connector.
+  // ignore: use_setters_to_change_properties
   void setConnector(InAppWebViewController newConnector) {
     _connector = newConnector;
   }

--- a/lib/src/widget/impl/turnstile_widget.dart
+++ b/lib/src/widget/impl/turnstile_widget.dart
@@ -157,6 +157,48 @@ class CloudflareTurnstile extends StatefulWidget
     );
   }
 
+  /// Create a Cloudflare Turnstile invisible widget.
+  ///
+  /// [siteKey] - A Cloudflare Turnstile sitekey.
+  /// It`s likely generated or obtained from the Cloudflare dashboard.
+  ///
+  /// [action] - A customer value that can be used to differentiate widgets under
+  /// the some sitekey in analytics and witch is returned upon validation.
+  ///
+  /// [cData] - A customer payload that can be used to attach customer data to the
+  /// challenge throughout its issuance and which is returned upon validation.
+  ///
+  /// [baseUrl] - A website url corresponding current turnstile widget.
+  ///
+  /// [options] - Configuration options for the Turnstile widget.
+  ///
+  /// [onTokenReceived] - A Callback invoked upon success of the challange.
+  /// The callback is passed a `token` that can be validated.
+  ///
+  /// [onTokenExpired] - A Callback invoke when the token expires and does not
+  /// reset the widget.
+  factory CloudflareTurnstile.invisible({
+    required String siteKey,
+    String? action,
+    String? cData,
+    String baseUrl = 'http://localhost',
+    i.OnTokenReceived? onTokenReceived,
+    i.OnTokenExpired? onTokenExpired,
+    i.OnTimeout? onTimeout,
+    TurnstileOptions? options,
+  }) {
+    return _TurnstileInvisible.init(
+      siteKey: siteKey,
+      action: action,
+      cData: cData,
+      baseUrl: baseUrl,
+      onTokenReceived: onTokenReceived,
+      onTokenExpired: onTokenExpired,
+      onTimeout: onTimeout,
+      options: options ?? TurnstileOptions(),
+    );
+  }
+
   /// This [siteKey] is associated with the corresponding widget configuration
   /// and is created upon the widget creation.
   ///
@@ -252,48 +294,6 @@ class CloudflareTurnstile extends StatefulWidget
 
   @override
   State<CloudflareTurnstile> createState() => _CloudflareTurnstileState();
-
-  /// Create a Cloudflare Turnstile invisible widget.
-  ///
-  /// [siteKey] - A Cloudflare Turnstile sitekey.
-  /// It`s likely generated or obtained from the Cloudflare dashboard.
-  ///
-  /// [action] - A customer value that can be used to differentiate widgets under
-  /// the some sitekey in analytics and witch is returned upon validation.
-  ///
-  /// [cData] - A customer payload that can be used to attach customer data to the
-  /// challenge throughout its issuance and which is returned upon validation.
-  ///
-  /// [baseUrl] - A website url corresponding current turnstile widget.
-  ///
-  /// [options] - Configuration options for the Turnstile widget.
-  ///
-  /// [onTokenReceived] - A Callback invoked upon success of the challange.
-  /// The callback is passed a `token` that can be validated.
-  ///
-  /// [onTokenExpired] - A Callback invoke when the token expires and does not
-  /// reset the widget.
-  factory CloudflareTurnstile.invisible({
-    required String siteKey,
-    String? action,
-    String? cData,
-    String baseUrl = 'http://localhost',
-    i.OnTokenReceived? onTokenReceived,
-    i.OnTokenExpired? onTokenExpired,
-    i.OnTimeout? onTimeout,
-    TurnstileOptions? options,
-  }) {
-    return _TurnstileInvisible.init(
-      siteKey: siteKey,
-      action: action,
-      cData: cData,
-      baseUrl: baseUrl,
-      onTokenReceived: onTokenReceived,
-      onTokenExpired: onTokenExpired,
-      onTimeout: onTimeout,
-      options: options ?? TurnstileOptions(),
-    );
-  }
 
   /// Retrives the current token from the widget.
   ///

--- a/lib/src/widget/impl/turnstile_widget_web.dart
+++ b/lib/src/widget/impl/turnstile_widget_web.dart
@@ -110,6 +110,9 @@ String _createViewType() {
 @JS('turnstile.render')
 external String? _renderWidget(String target);
 
+@JS('turnstile.remove')
+external void _removeWidget(String widgetId);
+
 /// Cloudflare Turnstile web implementation
 class CloudflareTurnstile extends StatefulWidget
     implements i.CloudflareTurnstile {
@@ -391,10 +394,20 @@ class _CloudflareTurnstileState extends State<CloudflareTurnstile> {
   Timer? _scriptLoadTimer;
   bool _isDisposed = false;
   bool _viewCreated = false;
+  web.EventListener? _beforeUnloadListener;
 
   @override
   void initState() {
     super.initState();
+
+    _beforeUnloadListener = ((web.Event event) {
+      if (widgetId != null) {
+        try {
+          _removeWidget(widgetId!);
+        } catch (_) {}
+      }
+    }).toJS;
+    web.window.addEventListener('beforeunload', _beforeUnloadListener);
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
@@ -455,11 +468,30 @@ class _CloudflareTurnstileState extends State<CloudflareTurnstile> {
     }
   }
 
+  int _renderRetryCount = 0;
+  static const int _maxRenderRetries = 10;
+
   void _renderTurnstileWidget() {
     if (_isDisposed || !mounted) return;
     if (widgetId != null) return; // Already rendered
 
-    widgetId = _renderWidget('.cf-turnstile_$_widgetViewId');
+    final selector = '.cf-turnstile_$_widgetViewId';
+    final element = web.document.querySelector(selector);
+
+    if (element == null) {
+      if (_renderRetryCount < _maxRenderRetries) {
+        _renderRetryCount++;
+        Future.delayed(const Duration(milliseconds: 100), () {
+          if (!_isDisposed && mounted) {
+            _renderTurnstileWidget();
+          }
+        });
+      }
+      return;
+    }
+
+    _renderRetryCount = 0;
+    widgetId = _renderWidget(selector);
     widget.controller?.widgetId = widgetId;
     if (mounted) {
       setState(() => _isWidgetReady = true);
@@ -527,6 +559,14 @@ class _CloudflareTurnstileState extends State<CloudflareTurnstile> {
     _isDisposed = true;
     _scriptLoadTimer?.cancel();
     _scriptLoadTimer = null;
+    if (_beforeUnloadListener != null) {
+      web.window.removeEventListener('beforeunload', _beforeUnloadListener);
+    }
+    if (widgetId != null) {
+      try {
+        _removeWidget(widgetId!);
+      } catch (_) {}
+    }
     _widget.remove();
     super.dispose();
   }


### PR DESCRIPTION
## Summary

- Add `beforeunload` listener to clean up Turnstile widget on browser refresh (F5), since `dispose()` doesn't fire on navigation/refresh
- Add retry logic for `_renderTurnstileWidget` when DOM element isn't ready yet (up to 10 retries, 100ms apart)
- Explicitly call `turnstile.remove()` in `dispose()` for proper cleanup
- Update example app with navigation scenarios to properly test widget lifecycle

Based on the work from #42 by @fatih-buyuk-mytech — thank you for identifying and fixing this issue!

Closes #42

## Test plan

- [x] Run example app in Chrome, press F5 — widget re-renders without errors
- [x] Remove/Add widget toggle — widget re-renders
- [x] Navigate away and back — widget re-renders
- [x] Replace page — old widget cleaned up, new one renders
- [x] Check browser console for no "widget already exists" errors